### PR TITLE
EntityCoordinates are BlockCoordinates.

### DIFF
--- a/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/EntityCoordinates.java
+++ b/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/EntityCoordinates.java
@@ -5,15 +5,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents the possible location of an entity in a Minecraft world.
  */
-public interface EntityCoordinates extends FacingCoordinates {
-
-    /**
-     * Gets the name of the world in which these coordinates are located.
-     *
-     * @return The name of the world in which these coordinates are located.
-     */
-    @NotNull
-    String getWorld();
+public interface EntityCoordinates extends FacingCoordinates, BlockCoordinates {
 
     /** {@inheritDoc} */
     @Override

--- a/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableBlockCoordinates.java
+++ b/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableBlockCoordinates.java
@@ -74,4 +74,16 @@ public interface MutableBlockCoordinates extends MutableCoordinates, BlockCoordi
     /** {@inheritDoc} */
     @Override
     MutableBlockCoordinates subtract(final double x, final double y, final double z);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableBlockCoordinates mutableCopy();
+
+    /** {@inheritDoc} */
+    @Override
+    BlockCoordinates immutableCopy();
+
+    /** {@inheritDoc} */
+    @Override
+    MutableBlockCoordinates getMidpoint(@NotNull final Coordinates o);
 }

--- a/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableEntityCoordinates.java
+++ b/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableEntityCoordinates.java
@@ -5,15 +5,19 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents a point in 3-dimensional space that also has a pitch and yaw, or facing, value.
  */
-public interface MutableEntityCoordinates extends EntityCoordinates, MutableFacingCoordinates {
+public interface MutableEntityCoordinates extends EntityCoordinates, MutableFacingCoordinates, MutableBlockCoordinates {
 
-    /**
-     * Sets the name of the world for where these coordinates are located.
-     *
-     * @param world the name of the world for where these coordinates are located.
-     * @return this object.
-     */
+    /** {@inheritDoc} */
+    @Override
     MutableEntityCoordinates setWorld(@NotNull final String world);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableEntityCoordinates setPitch(final float pitch);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableEntityCoordinates setYaw(final float yaw);
 
     /** {@inheritDoc} */
     @Override
@@ -26,14 +30,6 @@ public interface MutableEntityCoordinates extends EntityCoordinates, MutableFaci
     /** {@inheritDoc} */
     @Override
     MutableEntityCoordinates setZ(final double z);
-
-    /** {@inheritDoc} */
-    @Override
-    MutableFacingCoordinates setPitch(final float pitch);
-
-    /** {@inheritDoc} */
-    @Override
-    MutableFacingCoordinates setYaw(final float yaw);
 
     /** {@inheritDoc} */
     @Override
@@ -90,4 +86,8 @@ public interface MutableEntityCoordinates extends EntityCoordinates, MutableFaci
     /** {@inheritDoc} */
     @Override
     EntityCoordinates immutableCopy();
+
+    /** {@inheritDoc} */
+    @Override
+    MutableEntityCoordinates getMidpoint(@NotNull final Coordinates o);
 }

--- a/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableFacingCoordinates.java
+++ b/minecraftlink/src/main/java/com/dumptruckman/minecraft/pluginbase/minecraft/location/MutableFacingCoordinates.java
@@ -7,26 +7,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface MutableFacingCoordinates extends MutableCoordinates, FacingCoordinates {
 
-    /** {@inheritDoc} */
-    @Override
-    float getPitch();
-
-    /** {@inheritDoc} */
-    @Override
-    float getYaw();
-
-    /** {@inheritDoc} */
-    @Override
-    MutableFacingCoordinates setX(final double x);
-
-    /** {@inheritDoc} */
-    @Override
-    MutableFacingCoordinates setY(final double y);
-
-    /** {@inheritDoc} */
-    @Override
-    MutableFacingCoordinates setZ(final double z);
-
     /**
      * Sets the pitch of the facing.
      * @param pitch the new pitch for the facing.
@@ -40,6 +20,18 @@ public interface MutableFacingCoordinates extends MutableCoordinates, FacingCoor
      * @return this object.
      */
     MutableFacingCoordinates setYaw(final float yaw);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableFacingCoordinates setX(final double x);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableFacingCoordinates setY(final double y);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableFacingCoordinates setZ(final double z);
 
     /** {@inheritDoc} */
     @Override
@@ -88,4 +80,16 @@ public interface MutableFacingCoordinates extends MutableCoordinates, FacingCoor
     /** {@inheritDoc} */
     @Override
     MutableFacingCoordinates subtract(final double x, final double y, final double z);
+
+    /** {@inheritDoc} */
+    @Override
+    MutableFacingCoordinates mutableCopy();
+
+    /** {@inheritDoc} */
+    @Override
+    FacingCoordinates immutableCopy();
+
+    /** {@inheritDoc} */
+    @Override
+    MutableFacingCoordinates getMidpoint(@NotNull final Coordinates o);
 }


### PR DESCRIPTION
Everything starts with Coordinates. They have x, y and z.
Now FacingCoordinates adds pitch&yaw and BlockCoordinates add a world.
EntityCoordinates also adds a world, but is based on FacingCoordinates.
Conclusion: EntityCoordinates = FacingCoordinates + BlockCoordinates

This also cleans up the mutable interfaces a bit.

Old inheritance graph:
![pluginbase-location-inheritance](https://f.cloud.github.com/assets/754850/447084/afa315d0-b1ea-11e2-88fb-ef96195344a4.png)

New inheritance graph:
![pluginbase-new](https://f.cloud.github.com/assets/754850/447091/f3406fc2-b1ea-11e2-8e03-60618bf8f734.png)

I noticed this while fixing the MV3 location code that was broken in 304dfe64676033b0d8faa183754d5dc7c0f4b591.
